### PR TITLE
fix: yaml로직 수정

### DIFF
--- a/app/(dashboard)/pipelines/components/types.ts
+++ b/app/(dashboard)/pipelines/components/types.ts
@@ -5,7 +5,7 @@ export interface JobNodeData {
   name: string;
   image: string;
   commands: string;
-  environment?: Record<string, string | number>;
+  environment?: Record<string, string>;
   originalIndex?: number;
 }
 
@@ -13,7 +13,7 @@ export interface JobYaml {
   name: string;
   image: string;
   commands?: string;
-  environment?: Record<string, string | number>;
+  environment?: Record<string, string>;
   dependencies?: string[]; // 의존성 job 이름들
 }
 

--- a/app/(dashboard)/pipelines/components/utils.ts
+++ b/app/(dashboard)/pipelines/components/utils.ts
@@ -3,6 +3,21 @@ import * as YAML from 'yaml';
 import { JobNodeData, JobYaml } from './types';
 
 /**
+ * 노드 이름을 표시용 형태로 변환 (첫글자 대문자)
+ */
+const toDisplayName = (name: string): string => {
+  const normalized = name.toLowerCase();
+  return normalized.charAt(0).toUpperCase() + normalized.slice(1);
+};
+
+/**
+ * 노드 이름을 YAML용 형태로 변환 (소문자)
+ */
+const toYamlName = (name: string): string => {
+  return name.toLowerCase();
+};
+
+/**
  * YAML 문자열을 파싱하여 React Flow 노드로 변환
  * 기존 노드가 있으면 위치를 보존함
  */
@@ -35,7 +50,7 @@ export const yamlToNodes = (yamlString: string, existingNodes?: Node[]): Node[] 
           y: 100 + index * 150, // 세로로 순차 배치 (150px 간격)
         },
         data: {
-          name: job.name === 'build' ? 'Build' : job.name === 'test' ? 'Test' : job.name === 'deploy' ? 'Deploy' : (job.name || `Job ${index + 1}`),
+          name: toDisplayName(job.name || `Job ${index + 1}`),
           image: job.image || 'unknown',
           commands: job.commands || '',
           environment: job.environment,
@@ -45,7 +60,8 @@ export const yamlToNodes = (yamlString: string, existingNodes?: Node[]): Node[] 
     });
   } catch (error) {
     console.error('YAML 파싱 오류:', error);
-    return [];
+    // 빈 배열 대신 기본 노드를 반환하여 UI가 완전히 비워지는 것을 방지
+    return existingNodes || [];
   }
 };
 
@@ -85,6 +101,7 @@ export const yamlToEdges = (yamlString: string): Edge[] => {
     return edges;
   } catch (error) {
     console.error('YAML 간선 파싱 오류:', error);
+    // 빈 배열을 반환하여 간선 연결이 초기화됨을 명시
     return [];
   }
 };
@@ -122,7 +139,7 @@ export const nodesToYaml = (nodeList: Node[], edgeList: Edge[]): string => {
     })
     .map((node) => {
       const job: JobYaml = {
-        name: node.data.name === 'Build' ? 'build' : node.data.name === 'Test' ? 'test' : node.data.name === 'Deploy' ? 'deploy' : node.data.name,
+        name: toYamlName(node.data.name),
         image: node.data.image,
       };
 
@@ -140,9 +157,7 @@ export const nodesToYaml = (nodeList: Node[], edgeList: Edge[]): string => {
       const dependencies = dependenciesMap.get(node.data.name);
       if (dependencies && dependencies.length > 0) {
         // dependencies도 소문자로 변환
-        job.dependencies = dependencies.map(dep => 
-          dep === 'Build' ? 'build' : dep === 'Test' ? 'test' : dep === 'Deploy' ? 'deploy' : dep
-        ).sort(); // 알파벳 순으로 정렬하여 일관성 유지
+        job.dependencies = dependencies.map(dep => toYamlName(dep)).sort(); // 알파벳 순으로 정렬하여 일관성 유지
       }
 
       return job;


### PR DESCRIPTION
● ✅ 노드-YAML 연동 로직 검토 완료

  🔧 수정한 주요 문제점들:

  1. ✅ handleNodesChange 함수 수정
    - 이전: 아무것도 하지 않고
  changes를 그냥 반환
    - 수정: React Flow의
  onNodesChange를 올바르게 호출
  2. ✅ 대소문자 변환 로직 단순화
    - 이전: 복잡한 삼항 연산자 체인
    - 수정: toDisplayName(),
  toYamlName() 헬퍼 함수로 일관성 확보
  3. ✅ setTimeout 제거 및 안전한 상태
   관리
    - 이전: 비동기 setTimeout으로
  레이스 컨디션 위험
    - 수정: useEffect 기반의 반응형
  상태 관리
  4. ✅ 환경변수 타입 일관성
    - 이전: Record<string, string | 
  number>로 혼재
    - 수정: Record<string, string>로
  통일
  5. ✅ 에러 처리 개선
    - 이전: 에러 시 빈 배열 반환으로
  UI 깨짐
    - 수정: 기존 노드 유지로 안정성
  확보

  🎯 개선된 동작 방식:

  - YAML → 노드: YAML 변경 시 자동으로
   노드 생성/업데이트
  - 노드/간선 → YAML: 노드나 간선 변경
   시 자동으로 YAML 업데이트
  - 위치 변경: 노드 위치 변경은 YAML에
   영향 없음 (시각적 요소만)
  - 무한 루프 방지: 조건부 업데이트로
  무한 렌더링 방지